### PR TITLE
fix sys.proc.spawn

### DIFF
--- a/interpreter/sys.scm
+++ b/interpreter/sys.scm
@@ -172,9 +172,10 @@
          (let ((len (length args)))
             (if (= len 0)
                (err (vaquero-error-object 'bad-arguments `(sys.proc.spawn ,@args) "Shell command required.") cont)
-               (let ((cmd (car args)))
+               (let ((cmd (car args))
+		     (cmd-args  (cdr args)))
                   (define env (if (hte? opts 'env) (hash-table->alist (htr opts 'env)) '()))
-                  (define-values (stdout stdin pid stderr) (process* cmd '() env))
+                  (define-values (stdout stdin pid stderr) (process* cmd cmd-args env))
                   (cont
                      (vaquero-object
                         (list


### PR DESCRIPTION
changes it's signature, argument should now be seperate strings, first
string is the (full path to) executable, and the rest are it's args